### PR TITLE
Performance improvements

### DIFF
--- a/tests/test_openeo_integration.py
+++ b/tests/test_openeo_integration.py
@@ -1,0 +1,38 @@
+import pytest
+from datetime import datetime as dt
+from datetime import date as date
+import openeo
+
+spatial_extent = {'west': -100.08970034199719, 'east': -99.88035465800282, 'south': 19.39343565800281, 'north': 19.53214134199719,
+     'crs': 4326}
+
+connection = openeo.connect("openeo.vito.be").authenticate_oidc()
+
+def test_hillshade():
+    from world_water_toolbox import wwt
+
+    start_date_exclusion = date(2020,12,1)
+    month_end = date(2021,1,16)
+    cube = wwt.hillshade_mask(connection,spatial_extent,start_date_exclusion,month_end,75)
+    cube.download("hillshade.nc")
+
+def test_masked_s2_cube():
+    from world_water_toolbox import wwt
+
+    start_date_exclusion = date(2020,12,1)
+    month_end = date(2021,2,1)
+    cube = wwt.masked_s2_cube(connection,spatial_extent,start_date_exclusion,month_end,75)
+    cube.download("masked_clouds_hills3.nc")
+
+def test_full_example():
+    from world_water_toolbox import wwt
+
+    start = '20210101'
+    start = dt.strptime(start, "%Y%m%d").date()
+    end = '20210401'
+    end = dt.strptime(end, "%Y%m%d").date()
+    region = 'Deserts'
+    geometry = 'example/input_large/aoi.geojson'
+    rgb_processing=False
+
+    wwt.main("openeo.vito.be", start, end, region, geometry, rgb_processing, 85, 75)

--- a/tests/test_openeo_integration.py
+++ b/tests/test_openeo_integration.py
@@ -2,6 +2,7 @@ import pytest
 from datetime import datetime as dt
 from datetime import date as date
 import openeo
+from world_water_toolbox.wwt import s2_water_processing
 
 spatial_extent = {'west': -100.08970034199719, 'east': -99.88035465800282, 'south': 19.39343565800281, 'north': 19.53214134199719,
      'crs': 4326}
@@ -35,4 +36,49 @@ def test_full_example():
     geometry = 'example/input_large/aoi.geojson'
     rgb_processing=False
 
-    wwt.main("openeo.vito.be", start, end, region, geometry, rgb_processing, 85, 75)
+    wwt.main("openeo.vito.be", start, end, region, geometry, rgb_processing, 85, 75, use_sentinelhub=True)
+
+def test_full_example_cdse():
+    from world_water_toolbox import wwt
+
+    start = '20220101'
+    start = dt.strptime(start, "%Y%m%d").date()
+    end = '20220131'
+    end = dt.strptime(end, "%Y%m%d").date()
+    region = 'Deserts'
+    geometry = 'example/input_large/aoi.geojson'
+    rgb_processing=False
+
+    wwt.main("openeo-staging.dataspace.copernicus.eu", start, end, region, geometry, rgb_processing, 85, 75, use_sentinelhub=False)
+
+def test_multiple_months():
+    from world_water_toolbox import wwt
+
+    start = '20220101'
+    start = dt.strptime(start, "%Y%m%d").date()
+    end = '20220331'
+    end = dt.strptime(end, "%Y%m%d").date()
+    region = 'Deserts'
+    geometry = 'example/input_large/aoi.geojson'
+    rgb_processing=False
+
+    connection = openeo.connect("openeo-staging.dataspace.copernicus.eu").authenticate_oidc()
+    water_prob = wwt._water_extent_multiple_months(connection, start, end, geometry, region, 75, use_sentinelhub=False)
+    water_prob.execute_batch("WWT probability", format="GTiff",job_options={
+            "executor-memory": "2g",
+            "executor-memoryOverhead": "5g",
+            "executor-cores": 1
+        }, filename_prefix="Worldwater_probability")
+
+
+
+
+
+def test_local_processing():
+    from openeo.local import LocalConnection
+
+    local_conn = LocalConnection("./")
+    collection = local_conn.load_collection("/home/driesj/python/worldwater-toolbox/tests/masked_clouds_hills3.nc")
+    collection.metadata._orig_metadata["id"] = "SENTINEL2_L2A"
+    s2_cube, ndxi_cube, s2_cube_water = s2_water_processing(collection,"Deserts")
+    s2_cube_water.median_time().execute()

--- a/world_water_toolbox/wwt.py
+++ b/world_water_toolbox/wwt.py
@@ -143,7 +143,7 @@ def hillshade_mask(connection, spatial_extent, start_date_exclusion, month_end, 
 
     # angles are lower resolution, so we load them separately
     s2_angles = connection.load_collection(
-        'SENTINEL2_L2A_SENTINELHUB',
+        'SENTINEL2_L2A',
         spatial_extent=spatial_extent,
         temporal_extent=[start_date_exclusion, month_end],
         bands=['B01','sunAzimuthAngles', 'sunZenithAngles'],
@@ -448,7 +448,7 @@ def _water_probability(s1_median, s2_median_water, ndxi_median, region):
     # s1_median_water_mask = s1_median_water.mask(exclusion_mask.resample_cube_spatial(s1_median_water))
     # Calculate water extent for the S1 & S2 collection using logistic expression from the lookup table
     def s1_s2_water_function(data):
-        return LOOKUPTABLE[region]["S1_S2"](vv=data[0], ndvi=data[1], ndwi=data[2])
+        return LOOKUPTABLE[region]["S1_S2"](vv=data[0], ndvi=data[2], ndwi=data[1])
 
     s1_s2_cube = (
         s1_median.filter_bands(["VV"])

--- a/world_water_toolbox/wwt.py
+++ b/world_water_toolbox/wwt.py
@@ -366,7 +366,7 @@ def _water_extent(connection: openeo.Connection, month_start, month_end, start, 
     # Monthly median s2 image
     s2_median_water = s2_cube_water.filter_temporal([month_start, month_end]).median_time()
 
-    ndxi_median = ndxi_cube.median_time()
+    ndxi_median = ndxi_cube.filter_temporal([month_start, month_end]).median_time()
 
     # Normalized radar back-scatter
     s1_cube = sentinel1_preprocessing(connection, month_end, month_start, spatial_extent, use_sentinelhub)


### PR DESCRIPTION
This PR includes:

Performance improvements, by optimizing the process graph:
1. load cloud mask separately, this avoids loading other bands for chunks that are fully masked
2. hillshade gets computed separately, bands are lower resolution, merged into cloudmask
3. remove resample_cube_spatial where possible: simplifies process graph analysis for the backend
4. Sentinel-1 hv band was not used, so removed it
5. converted a series of 'mask' processes into an inline function using a callback, avoiding subsequent 'joins' of datacubes, this had less impact than expected

- allow running also on other openEO backends
- initial version of UDP code